### PR TITLE
Add body parser and allow using body to fingerprint requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # HTTP JSON API Recorder
-*Record API responses and replay them offline.*
+*Record API responses and replay them offline. Useful for UI testing setups.*
 
 Runs a proxy server that acts in two modes:
 - recording mode: stores every responses of target API to specified directory.
@@ -11,22 +11,55 @@ Runs a proxy server that acts in two modes:
 $ npm install api-recorder -g
 ```
 
-## Usage
+## Configuration
 
-```sh
-$ api-recorder -p=3000 -d=~/Desktop/my_api -t=http://my.api:1234
+```json
+{
+  "port": 3000,
+  "directory": "~/offline_data",
+  "target": "http://my.api.local:8080",
+  "fingerprint": [
+    "method",
+    "url",
+    "query",
+    "body",
+    {
+      "headers": [
+        "user-agent",
+        "accept-language",
+        "host"
+      ]
+    }
+  ]
+}
 ```
 
-You can then configure your application to point to the proxy.
+### `port` *Integer*
+Port used by the proxy.
 
-**Arguments**
-- **`-p`, `--port`:** Port the proxy will use.
-- **`-d`, `--directory`:** Directory where recorded responses should be written / read.
-- **`-t`, `--target`:** Optional. When defined, the proxy reaches out to the real API and records it to specified `directory`. When not defined, the proxy simply returns the responses from the specified `directory`.
+### `directory` *String*
+Directory to write to / read from API responses.
+
+### `target` *String*
+Real server hosting the API to record.
+
+### `fingerprint` *Array*
+List of keys from the `request` object to use to "fingerprint" the request. Can be specifed as an object when reading request object properties (for example `headers`).
+
+
+## Record API responses
+```sh
+$ api-recorder -c=/path/to/config.json
+```
+
+## Replay API responses (offline mode)
+```sh
+$ api-recorder -c=/path/to/config.json --offline
+```
 
 ## TODO
 
-- tests
-- support non-JSON APIs
-- allow request fingerprinting customization
-- allow responses delaying by configuration
+- [x] allow request fingerprinting customization
+- [ ] allow responses delaying by configuration
+- [ ] tests
+- [ ] support non-JSON APIs

--- a/lib/json.js
+++ b/lib/json.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports.prettify = (obj) => JSON.stringify(obj, null, '  ');

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -2,10 +2,7 @@
 
 const {resolve, join} = require('path');
 
-module.exports = (req, path) => {
-  let dir = resolve(path);
-  if (path[0] === '~') {
-      dir = join(process.env.HOME, path.slice(1));
-  }
-  return join(dir, req.path, req.fingerprint);
-};
+const resolvePath = path => join(path[0] === '~' ? join(process.env.HOME, path.slice(1)) : resolve(path));
+const resolveRequestPath = (req, path) => join(resolvePath(path), req.path, req.fingerprint);
+
+module.exports = { resolvePath, resolveRequestPath };

--- a/lib/write.js
+++ b/lib/write.js
@@ -3,7 +3,8 @@
 const mkdirp = require('mkdirp'),
       {apply, auto} = require('async'),
       {writeFile} = require('fs'),
-      {join} = require('path');
+      {join} = require('path'),
+      {prettify} = require('./json');
 
 const {
   HEADERS_FILE,
@@ -14,7 +15,7 @@ const format = data => {
   try {
     data = JSON.parse(data);
   } catch (e) {}
-  return JSON.stringify(data, null, '  ');
+  return prettify(data);
 };
 
 module.exports = (dir, headers, body) => {

--- a/middleware/fingerprint.js
+++ b/middleware/fingerprint.js
@@ -1,33 +1,22 @@
 'use strict';
 
-const hash = require('object-hash');
+const hash = require('object-hash'),
+  {prettify} = require('../lib/json');
 
-const filters = {
-  url: null,
-  method: null,
-  params: null,
-  query: null,
-  body: null,
-  headers: ['user-agent', 'accept-language']
-};
+module.exports = filters => (req, res, next) => {
+  const process = filter => {
+    switch (filter.constructor) {
+      case Object:
+      return Object
+        .keys(filter)
+        .map(key => filter[key].map(subfilter => req[key][subfilter]));
+      case String:
+        return {[filter]: req[filter]};
+    }
+  };
 
-const process = (subfilters, data) => {
-  if (subfilters && subfilters.length > 0) {
-    return Object.keys(data)
-      .filter(key => subfilters.includes(key))
-      .reduce((obj, key) => {
-        obj[key] = data[key];
-        return obj;
-      }, {});
-  } else {
-    return data;
-  }
-};
+  req.fingerprint = prettify(filters.map(process));
+  req.id = hash(req.fingerprint);
 
-module.exports = (req, res, next) => {
-  const dictionary = Object.keys(filters).map(filter => {
-    return process(filters[filter], req[filter]);
-  });
-  req.fingerprint = hash(dictionary);
   next();
 };

--- a/middleware/log.js
+++ b/middleware/log.js
@@ -3,7 +3,7 @@
 require('colors');
 
 module.exports = (req, res, next) => {
-  const out = `[${req.fingerprint.magenta}] ${req.method.cyan} ${req.url.yellow}`;
+  const out = `[${req.id.magenta}] ${req.method.cyan} ${req.path.yellow}`;
   console.log(out);
   next();
 };

--- a/middleware/record.js
+++ b/middleware/record.js
@@ -1,17 +1,18 @@
 'use strict';
 
 const {createProxyServer} = require('http-proxy'),
-      resolve = require('../lib/resolve'),
+      {resolveRequestPath} = require('../lib/resolve'),
       write = require('../lib/write');
 
-module.exports = ({target, dir}) => {
+module.exports = ({target, directory}) => {
   const proxy = createProxyServer({target});
+
   proxy.on('proxyRes', (proxyRes, req) => {
     let response = '';
     proxyRes
       .on('data', chunk => response += chunk)
       .on('end', () => {
-        const filename = resolve(req, dir),
+        const filename = resolveRequestPath(req, directory),
               {headers} = proxyRes;
         write(filename, headers, response);
       });

--- a/middleware/replay.js
+++ b/middleware/replay.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const resolve = require('../lib/resolve'),
+const {resolveRequestPath} = require('../lib/resolve'),
       read = require('../lib/read');
 
-module.exports = ({dir}) => {
+module.exports = ({directory}) => {
   return (req, res) => {
-    const path = resolve(req, dir);
+    const path = resolveRequestPath(req, directory);
     read(path, result => {
       const {headers, body} = result;
       if (headers) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "async": "^2.1.2",
+    "body-parser": "^1.15.2",
     "colors": "^1.1.2",
     "express": "^4.14.0",
     "http-proxy": "^1.15.2",


### PR DESCRIPTION
Remove CLI arguments, and only accept a config path argument.
Allow specifying fingerprint params via config.