### PR TITLE
Put restream fix (see 4db6c858496bae6fc2969e39d711cf28ed522c10) behin…

### DIFF
--- a/middleware/record.js
+++ b/middleware/record.js
@@ -4,19 +4,21 @@ const {createProxyServer} = require('http-proxy'),
       {resolveRequestPath} = require('../lib/resolve'),
       write = require('../lib/write');
 
-module.exports = ({target, directory}) => {
+module.exports = ({target, directory, restream}) => {
   const proxy = createProxyServer({target, secure: false});
 
   // https://github.com/nodejitsu/node-http-proxy/issues/180
   // https://github.com/nodejitsu/node-http-proxy/blob/d0e000e1f91a969f1711eb3be7d1acb16c4538df/examples/middleware/bodyDecoder-middleware.js#L37-L47
-  proxy.on('proxyReq', (proxyReq, req) => {
-    if (req.body) {
-      const body = JSON.stringify(req.body);
-      proxyReq.setHeader('Content-Type','application/json');
-      proxyReq.setHeader('Content-Length', Buffer.byteLength(body));
-      proxyReq.write(body);
-    }
-  });
+  if (restream) {
+    proxy.on('proxyReq', (proxyReq, req) => {
+      if (req.body) {
+        const body = JSON.stringify(req.body);
+        proxyReq.setHeader('Content-Type','application/json');
+        proxyReq.setHeader('Content-Length', Buffer.byteLength(body));
+        proxyReq.write(body);
+      }
+    });
+  }
 
   proxy.on('proxyRes', (proxyRes, req) => {
     let response = '';


### PR DESCRIPTION
…d an undocumented config flag as it currently breaks behavior for requests with content-type other than application/json. Should be fixed with a more elegant solution in the future.