### PR TITLE
Autofix data in offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ $ api-recorder -c=/path/to/config.json
 $ api-recorder -c=/path/to/config.json --offline
 ```
 
+#### Replay API responses that are already recorded, record others
+```sh
+$ api-recorder -c=/path/to/config.json --offline --autofix
+```
+
 ### Node API
 
 ```javascript

--- a/bin/api-recorder.js
+++ b/bin/api-recorder.js
@@ -7,6 +7,7 @@ const apiRecorder = require('../'),
   argsMap = {
     config: ['-c', '--config'],
     offline: ['-o', '--offline'],
+    autofix: ['-a', '--autofix'],
     port: ['-p', '--port'],
     target: ['-t', '--target'],
     directory: ['-d', '--directory'],

--- a/index.js
+++ b/index.js
@@ -24,6 +24,5 @@ module.exports = args => {
   app.use(log(config));
   app.use(replay(config));
   app.use(record(config));
-  app.use(log(config));
   return app.listen(config.port, serviceStarted(config));
 };

--- a/index.js
+++ b/index.js
@@ -16,18 +16,14 @@ module.exports = args => {
     args
   );
 
-  const app = express(),
-    handler = config.offline ? replay : record;
+  const app = express();
 
   app.disable('x-powered-by');
   app.use(bodyParser.json());
   app.use(fingerprint(config.fingerprint));
-  if (!config.offline) {
-    app.use(log(config));
-  }
-  app.use(handler(config));
-  if (config.offline) {
-    app.use(log(config));
-  }
+  app.use(log(config));
+  app.use(replay(config));
+  app.use(record(config));
+  app.use(log(config));
   return app.listen(config.port, serviceStarted(config));
 };

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,17 +1,21 @@
 require('colors');
 
 module.exports.serviceStarted = config => {
-  const {log, offline, target, port, directory} = config;
+  const {log, offline, autofix, target, port, directory} = config;
   const lines = [
     '',
-    `API Recorder running on port: ${port.toString().cyan}`
+    `API Recorder running on port ${port.toString().cyan}`
   ];
 
   if (!offline) {
-    lines.push(`Proxying to: ${target.cyan}`);
-    lines.push(`Recording data to: ${directory.cyan}`);
+    lines.push(`Proxying to ${target.cyan}`);
+    lines.push(`Recording data to ${directory.cyan}`);
   } else {
-    lines.push(`Reading data from: ${directory.cyan}`);
+    lines.push(`Reading data from ${directory.cyan}`);
+    if (autofix) {
+      lines.push(`Will proxy to ${target.cyan} if needed`);
+      lines.push(`Will record data to ${directory.cyan} if needed`);
+    }
   }
   lines.push('\n\n');
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -2,24 +2,23 @@ require('colors');
 
 module.exports.serviceStarted = config => {
   const {log, offline, autofix, target, port, directory} = config;
-  const lines = [
-    '',
-    `API Recorder running on port ${port.toString().cyan}`
-  ];
+  const lines = [];
 
   if (!offline) {
-    lines.push(`Proxying to ${target.cyan}`);
-    lines.push(`Recording data to ${directory.cyan}`);
+    lines.push(`  Proxying to ${target.cyan}`);
+    lines.push(`  Recording data to ${directory.cyan}`);
   } else {
-    lines.push(`Reading data from ${directory.cyan}`);
+    lines.push(`  Reading data from ${directory.cyan}`);
     if (autofix) {
-      lines.push(`Will proxy to ${target.cyan} if needed`);
-      lines.push(`Will record data to ${directory.cyan} if needed`);
+      lines.push(`  Will proxy to ${target.cyan} if needed`);
+      lines.push(`  Will record data to ${directory.cyan} if needed`);
     }
   }
   lines.push('\n\n');
 
   if (log !== false) {
-    console.log(lines.join('\n  '));
+    console.log(`
+API Recorder running on port ${port.toString().cyan}`);
+    console.log(lines.join('\n'));
   }
 };

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -11,4 +11,4 @@ const resolveRequestPath = (req, path) => {
   return requestPath;
 };
 
-module.exports = {resolvePath, resolveRequestPath};
+module.exports = {requestsIdsIndexes, resolvePath, resolveRequestPath};

--- a/lib/write.js
+++ b/lib/write.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('colors');
+
 const mkdirp = require('mkdirp'),
       {apply, auto} = require('async'),
       {writeFile} = require('fs'),
@@ -34,5 +36,12 @@ module.exports = (dir, status, headers, body) => {
     status: ['prepare', write(STATUS_FILE, status)],
     headers: ['prepare', write(HEADERS_FILE, headers)],
     body: ['prepare', write(BODY_FILE, body)]
+  }, (err) => {
+    if (err) {
+      console.log(err.red);
+    } else {
+      console.log(`Wrote response files to: ${dir.green}`);
+    }
+
   });
 };

--- a/middleware/log.js
+++ b/middleware/log.js
@@ -8,10 +8,11 @@ module.exports = config => {
     // Might add more options in the future.
     if (config.log !== false) {
       const out = `
-  ${'id'.magenta}: ${req.id.yellow}
-  ${'method'.magenta}: ${req.method.yellow}
-  ${'path'.magenta}: ${req.path.yellow}
-  ${'status'.magenta}: ${res.statusCode.toString().yellow}
+Request:
+  ${'id'.magenta}: ${req.id.cyan}
+  ${'method'.magenta}: ${req.method.cyan}
+  ${'path'.magenta}: ${req.path.cyan}
+  ${'status'.magenta}: ${res.statusCode.toString().cyan}
       `;
       console.log(out);
     }


### PR DESCRIPTION
Add `--autofix` flag: records from real API when running in offline mode and data for a given request is missing